### PR TITLE
fix: remove remaining router entry for Table.vue

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -39,11 +39,6 @@ const router = createRouter({
           component: () => import('@/views/uikit/Button.vue'),
         },
         {
-          path: '/uikit/table',
-          name: 'table',
-          component: () => import('@/views/uikit/Table.vue'),
-        },
-        {
           path: '/uikit/list',
           name: 'list',
           component: () => import('@/views/uikit/List.vue'),


### PR DESCRIPTION
Removed a leftover entry in the router. Table was removed some time ago.