### PR TITLE
fix: write server entries to SERVERS collection

### DIFF
--- a/api/src/server/server.service.ts
+++ b/api/src/server/server.service.ts
@@ -56,7 +56,7 @@ export class ServerService {
         description: serverCreateDto.description,
       } as ServerEntry;
       dbData.push(newEntry);
-      chain.set(COLLECTION.USERS, dbData);
+      chain.set(COLLECTION.SERVERS, dbData);
       this.dbService.flushDataToDisk = true;
       return resolve(newEntry);
     });


### PR DESCRIPTION
In server.service.ts create(), chain.set() was incorrectly targeting COLLECTION.USERS instead of COLLECTION.SERVERS, causing server entries to overwrite the users collection on every create() call.